### PR TITLE
Fix boolean value representation on schema in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,7 +99,7 @@ you can use Python's ``json`` module to load a JSON Schema as string)::
                 "price": {
                     "type": "number",
                     "minimum": 0,
-                    "exclusiveMinimum": true
+                    "exclusiveMinimum": True
                 }
             },
             "required": ["id", "name", "price"]


### PR DESCRIPTION
A boolean value is misrepresented in a dict in the README file.