### PR TITLE
Allows array as paths by converting absolute_path elements to str

### DIFF
--- a/scrapy_jsonschema/pipeline.py
+++ b/scrapy_jsonschema/pipeline.py
@@ -30,7 +30,8 @@ class JsonSchemaValidatePipeline(object):
             required_match = self.REQUIRED_RE.search(error.message)
             if required_match:
                 absolute_path.append(required_match.group(1))
-            path = '.'.join(absolute_path)
+            abs_path = [str(i) for i in absolute_path]
+            path = '.'.join(abs_path)
             self.stats.inc_value(self.STAT_FMT.format(field=path))
             paths_messages.append((path, error.message))
         if errors:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from scrapy.statscol import StatsCollector
+from scrapy.statscollectors import StatsCollector
 from scrapy.exceptions import DropItem
 from scrapy_jsonschema.pipeline import JsonSchemaValidatePipeline
 from scrapy_jsonschema.item import JsonSchemaItem


### PR DESCRIPTION
As of #6, when there is an array in the json, the absolute_path of the error message breaks because arrays uses int as index. So we could just convert every element of absolute_path to str.