### PR TITLE
only support scrapy < 2.2.*

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 jsonschema[format]
-scrapy
+scrapy<2.2.*
 six


### PR DESCRIPTION
Alternative fix for #18 